### PR TITLE
Fixing the defect of navigating the images with the same title

### DIFF
--- a/src/main/java/ImageHoster/controller/ImageController.java
+++ b/src/main/java/ImageHoster/controller/ImageController.java
@@ -36,18 +36,18 @@ public class ImageController {
     }
 
     //This method is called when the details of the specific image with corresponding title are to be displayed
-    //The logic is to get the image from the databse with corresponding title. After getting the image from the database the details are shown
-    //First receive the dynamic parameter in the incoming request URL in a string variable 'title' and also the Model type object
-    //Call the getImageByTitle() method in the business logic to fetch all the details of that image
+    //The logic is to get the image from the database with corresponding title. After getting the image from the database the details are shown
+    //First receive the dynamic parameter in the incoming request URL in a Integer variable image id and also the Model type object
+    //Call the getImageById() method in the business logic to fetch all the details of that image
     //Add the image in the Model type object with 'image' as the key
     //Return 'images/image.html' file
 
     //Also now you need to add the tags of an image in the Model type object
     //Here a list of tags is added in the Model type object
     //this list is then sent to 'images/image.html' file and the tags are displayed
-    @RequestMapping("/images/{title}")
-    public String showImage(@PathVariable("title") String title, Model model) {
-        Image image = imageService.getImageByTitle(title);
+    @RequestMapping("/images/{imageId}/{title}")
+    public String showImage(@PathVariable("imageId") Integer imageId, Model model) {
+        Image image = imageService.getImageById(imageId);
         model.addAttribute("image", image);
         model.addAttribute("tags", image.getTags());
         return "images/image";

--- a/src/main/java/ImageHoster/repository/ImageRepository.java
+++ b/src/main/java/ImageHoster/repository/ImageRepository.java
@@ -59,6 +59,19 @@ public class ImageRepository {
             return null;
         }
     }
+    
+    //The method creates an instance of EntityManager
+    //Executes JPQL query to fetch the image from the database with corresponding Image id
+    //Returns the image in case the image is found in the database
+    //Returns null if no image is found in the database
+    public Image getImageById(Integer imageId) {
+      try {
+        EntityManager em = emf.createEntityManager();
+        return em.find(Image.class, imageId);
+      } catch(NoResultException nre) {
+        return null;
+      }
+    }
 
     //The method creates an instance of EntityManager
     //Executes JPQL query to fetch the image from the database with corresponding id

--- a/src/main/java/ImageHoster/service/ImageService.java
+++ b/src/main/java/ImageHoster/service/ImageService.java
@@ -30,6 +30,11 @@ public class ImageService {
     public Image getImageByTitle(String title) {
         return imageRepository.getImageByTitle(title);
     }
+    
+    //The method calls the getImageById() method in Repository and passes id of the image to be fetched
+    public Image getImageById(Integer imageId) {
+      return imageRepository.getImageById(imageId);
+    }
 
     //The method calls the getImage() method in the Repository and passes the id of the image to be fetched
     public Image getImage(Integer imageId) {

--- a/src/main/resources/templates/images.html
+++ b/src/main/resources/templates/images.html
@@ -18,7 +18,7 @@
         </div>
 
         <!--Change <a th:href="'/images/' + ${i.title}"> to <a th:href="'/images/' +${i.id} +'/' +${i.title}">-->
-        <a th:href="'/images/' + ${i.title}">
+        <a th:href="'/images/' +${i.id} +'/' +${i.title}">
             <h3 th:text="${i.title}">Title of image</h3>
         </a>
         <i>Posted On: </i> <span th:text="${i.date}"></span>

--- a/target/classes/templates/images.html
+++ b/target/classes/templates/images.html
@@ -18,7 +18,7 @@
         </div>
 
         <!--Change <a th:href="'/images/' + ${i.title}"> to <a th:href="'/images/' +${i.id} +'/' +${i.title}">-->
-        <a th:href="'/images/' + ${i.title}">
+        <a th:href="'/images/' +${i.id} +'/' +${i.title}">
             <h3 th:text="${i.title}">Title of image</h3>
         </a>
         <i>Posted On: </i> <span th:text="${i.date}"></span>


### PR DESCRIPTION
Retriving the image by its ID instead of title will provide unique image.
To do this following changes are made
- Modified the anchor tag to change URL
- Implemented the method getImageById(Integer imageId) in ImageRepository and calling it from service class
- Changed the RequestMapping for showImage method by adding imageId in ImageController class